### PR TITLE
Limit cstruct to anything before 4.0.0

### DIFF
--- a/x509.opam
+++ b/x509.opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.02.2"}
   "ppx_sexp_conv"
   "result"
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" < "4.0.0"}
   "sexplib"
   "asn1-combinators" {>= "0.2.0"}
   "ptime"


### PR DESCRIPTION
This allows us to build the library without pinning a cstruct version